### PR TITLE
Fix card hover scale breaking image alignment

### DIFF
--- a/default.css
+++ b/default.css
@@ -133,12 +133,22 @@ body::after,
 .primaryImageWrapper img,
 .listItemImage button img {
   object-fit: cover;
-  transition: transform var(--jf-anim), filter var(--jf-anim);
+  transition: filter var(--jf-anim);
+}
+
+.cardImageContainer,
+.primaryImageWrapper {
+  transition: transform var(--jf-anim);
+  transform-origin: center;
+}
+
+.card:hover .cardImageContainer,
+.primaryImageWrapper:hover {
+  transform: scale(1.03);
 }
 
 .card:hover .cardImageContainer img,
 .primaryImageWrapper:hover img {
-  transform: scale(1.04);
   filter: saturate(1.1) contrast(1.02);
 }
 


### PR DESCRIPTION
## Summary
- avoid overriding Jellyfin's image transforms by moving the hover scale effect to the card container
- keep the hover saturation polish without shifting poster images out of frame

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c91434497c83218fc5754603348909