### PR TITLE
Use CSS scale property to preserve Jellyfin transforms

### DIFF
--- a/default.css
+++ b/default.css
@@ -131,14 +131,42 @@ body::after,
 
 .card .cardImageContainer img,
 .primaryImageWrapper img,
-.listItemImage button img {
+.listItemImage button img,
+.listItemImageButton img {
   object-fit: cover;
-  transition: transform var(--jf-anim), filter var(--jf-anim);
+  transition: filter var(--jf-anim);
+}
+
+@supports (scale: 1) {
+  .card .cardImageContainer img,
+  .primaryImageWrapper img,
+  .listItemImage button img,
+  .listItemImageButton img {
+    scale: 1;
+    transform-origin: center;
+    transition: scale var(--jf-anim), filter var(--jf-anim);
+  }
+
+  .card:hover .cardImageContainer img,
+  .card:focus-within .cardImageContainer img,
+  .primaryImageWrapper:hover img,
+  .primaryImageWrapper:focus-within img,
+  .listItemImage button:hover img,
+  .listItemImage button:focus-visible img,
+  .listItemImageButton:hover img,
+  .listItemImageButton:focus-visible img {
+    scale: 1.03;
+  }
 }
 
 .card:hover .cardImageContainer img,
-.primaryImageWrapper:hover img {
-  transform: scale(1.04);
+.card:focus-within .cardImageContainer img,
+.primaryImageWrapper:hover img,
+.primaryImageWrapper:focus-within img,
+.listItemImage button:hover img,
+.listItemImage button:focus-visible img,
+.listItemImageButton:hover img,
+.listItemImageButton:focus-visible img {
   filter: saturate(1.1) contrast(1.02);
 }
 


### PR DESCRIPTION
## Summary
- rely on the CSS `scale` property for the poster hover zoom so Jellyfin's own transforms stay intact
- gate the new scaling with `@supports` and extend the hover/focus selectors to cover list buttons and primary wrappers

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c91434497c83218fc5754603348909