### PR TITLE
Use CSS scale property to preserve Jellyfin transforms

### DIFF
--- a/default.css
+++ b/default.css
@@ -131,14 +131,51 @@ body::after,
 
 .card .cardImageContainer img,
 .primaryImageWrapper img,
-.listItemImage button img {
+.listItemImage button img,
+.listItemImage a img,
+.listItemImageButton img {
+  display: block;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  transition: transform var(--jf-anim), filter var(--jf-anim);
+  object-position: center;
+  transition: filter var(--jf-anim);
+}
+
+@supports (scale: 1) {
+  .card .cardImageContainer img,
+  .primaryImageWrapper img,
+  .listItemImage button img,
+  .listItemImage a img,
+  .listItemImageButton img {
+    transform-origin: center;
+    transition: scale var(--jf-anim), filter var(--jf-anim);
+  }
+
+  .card:hover .cardImageContainer img,
+  .card:focus-within .cardImageContainer img,
+  .primaryImageWrapper:hover img,
+  .primaryImageWrapper:focus-within img,
+  .listItemImage button:hover img,
+  .listItemImage button:focus-visible img,
+  .listItemImage a:hover img,
+  .listItemImage a:focus-visible img,
+  .listItemImageButton:hover img,
+  .listItemImageButton:focus-visible img {
+    scale: 1.03;
+  }
 }
 
 .card:hover .cardImageContainer img,
-.primaryImageWrapper:hover img {
-  transform: scale(1.04);
+.card:focus-within .cardImageContainer img,
+.primaryImageWrapper:hover img,
+.primaryImageWrapper:focus-within img,
+.listItemImage button:hover img,
+.listItemImage button:focus-visible img,
+.listItemImage a:hover img,
+.listItemImage a:focus-visible img,
+.listItemImageButton:hover img,
+.listItemImageButton:focus-visible img {
   filter: saturate(1.1) contrast(1.02);
 }
 


### PR DESCRIPTION
## Summary
- rely on the CSS `scale` property for the poster hover zoom so Jellyfin's own transforms stay intact
- gate the new scaling with `@supports` and extend the hover/focus selectors to cover list buttons and primary wrappers
- ensure poster images fill their wrappers evenly so zooming the browser no longer shifts titles like "New Kids"

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c91434497c83218fc5754603348909